### PR TITLE
Remove reference to Juno

### DIFF
--- a/js/landing-page.js
+++ b/js/landing-page.js
@@ -139,7 +139,7 @@ var items = {
         },
         {
             title: "Feature-complete on remote machines",
-            description: "All Juno features are available on remote machines, too; " +
+            description: "All features are available on remote machines, too; " +
                          "including the debugger and plotting.",
             position: {
                 left: 60,


### PR DESCRIPTION
There is a reference to Juno when hovering on the "Feature-complete on remote machines" popup on the "Remote" tab of the main page:
https://github.com/julia-vscode/julia-vscode.github.io/blob/243947a5d00b47ff65b9c133da287697f84aeada/js/landing-page.js#L142
but I think it's just a leftover from Juno's website (the same piece is at https://github.com/JunoLab/junolab.github.io/blob/42bc5f89a22f695bc4499a785d7a385a621cf9ec/js/landing-page.js#L187) so this is just to remove it.
